### PR TITLE
fix(i18n): replace hardcoded validation and empty-state strings

### DIFF
--- a/src/features/account/view-account.tsx
+++ b/src/features/account/view-account.tsx
@@ -36,7 +36,9 @@ export const ViewAccount = () => {
     defaultValues: { name: session.data?.user?.name ?? '' },
     validators: {
       onSubmit: z.object({
-        name: z.string().nonempty({ error: 'Name could not be empty' }),
+        name: z
+          .string()
+          .nonempty({ error: t('account:user.updateName.required') }),
       }),
     },
     onSubmit: async (submission) => {

--- a/src/features/auth/view-auth-onboarding.tsx
+++ b/src/features/auth/view-auth-onboarding.tsx
@@ -17,7 +17,9 @@ export const ViewAuthOnboarding = () => {
     defaultValues: { name: '' },
     validators: {
       onSubmit: z.object({
-        name: z.string().nonempty({ error: 'Name could not be empty' }),
+        name: z
+          .string()
+          .nonempty({ error: t('auth:onboarding.name.required') }),
       }),
     },
     onSubmit: async (submission) => {

--- a/src/features/books/view-books.tsx
+++ b/src/features/books/view-books.tsx
@@ -3,6 +3,7 @@ import { FlashList } from '@shopify/flash-list';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { Link } from 'expo-router';
 import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ActivityIndicator, View } from 'react-native';
 
 import { api } from '@/lib/hey-api/api';
@@ -15,6 +16,8 @@ import { BookCover, COVER_HEIGHT } from '@/features/books/book-cover';
 import { ViewTabContent } from '@/layout/view-tab-content';
 
 export const ViewBooks = () => {
+  const { t } = useTranslation(['books']);
+
   const books = useInfiniteQuery({
     ...api.bookGetAllInfiniteOptions(),
     getNextPageParam: (lastPage) => lastPage.nextCursor,
@@ -66,7 +69,7 @@ export const ViewBooks = () => {
           </View>
         ))
         .match('error', () => <></>)
-        .match('empty', () => <Text>There is no books</Text>)
+        .match('empty', () => <Text>{t('books:list.empty')}</Text>)
         .match('default', ({ data }) => (
           <FlashList
             data={data}

--- a/src/locales/en/account.json
+++ b/src/locales/en/account.json
@@ -7,7 +7,8 @@
       "title": "Update name",
       "cancel": "Cancel",
       "save": "Save",
-      "error": "An error occurred during name update"
+      "error": "An error occurred during name update",
+      "required": "Name cannot be empty"
     }
   },
   "displayPreferences": {

--- a/src/locales/en/auth.json
+++ b/src/locales/en/auth.json
@@ -19,7 +19,10 @@
   "onboarding": {
     "title": "Welcome",
     "subtitle": "Let's personalize your experience",
-    "name": { "label": "What is your name?" },
+    "name": {
+      "label": "What is your name?",
+      "required": "Name cannot be empty"
+    },
     "continue": "Continue"
   },
   "signOut": {

--- a/src/locales/en/books.json
+++ b/src/locales/en/books.json
@@ -4,5 +4,8 @@
     "author": "Author",
     "genre": "Genre",
     "publisher": "Publisher"
+  },
+  "list": {
+    "empty": "There are no books"
   }
 }

--- a/src/locales/fr/account.json
+++ b/src/locales/fr/account.json
@@ -7,7 +7,8 @@
       "title": "Modifier le nom",
       "cancel": "Annuler",
       "save": "Sauvegarder",
-      "error": "Une erreur est survenue lors de la modification du nom"
+      "error": "Une erreur est survenue lors de la modification du nom",
+      "required": "Le nom ne peut pas être vide"
     }
   },
   "displayPreferences": {

--- a/src/locales/fr/auth.json
+++ b/src/locales/fr/auth.json
@@ -19,7 +19,10 @@
   "onboarding": {
     "title": "Bienvenue",
     "subtitle": "Personnalisons votre expérience",
-    "name": { "label": "Quel est votre nom ?" },
+    "name": {
+      "label": "Quel est votre nom ?",
+      "required": "Le nom ne peut pas être vide"
+    },
     "continue": "Continuer"
   },
   "signOut": {

--- a/src/locales/fr/books.json
+++ b/src/locales/fr/books.json
@@ -4,5 +4,8 @@
     "author": "Auteur",
     "genre": "Genre",
     "publisher": "Éditeur"
+  },
+  "list": {
+    "empty": "Aucun livre disponible"
   }
 }


### PR DESCRIPTION
Wraps three previously hardcoded English strings in i18n keys so they translate to French (and any future locale): the books empty-state ("There is no books" — also fixes the grammar to "There are no books"), the auth onboarding name validator, and the account update-name validator. Adds matching keys to en/fr namespaces.