### PR TITLE
feat(a11y): label tab buttons and add native button role

### DIFF
--- a/src/app/(logged)/(tabs)/_layout.tsx
+++ b/src/app/(logged)/(tabs)/_layout.tsx
@@ -90,6 +90,7 @@ export default function TabLayout() {
           options={{
             title: t(tab.translationKey),
             headerShown: tab.headerShown,
+            tabBarAccessibilityLabel: t(tab.translationKey),
             tabBarIcon: (props) => {
               const TabIcon = props.focused ? tab.iconFocused : tab.icon;
               return (

--- a/src/components/haptic-tab.tsx
+++ b/src/components/haptic-tab.tsx
@@ -5,6 +5,7 @@ import { ComponentProps } from 'react';
 export const HapticTab = (props: ComponentProps<typeof PlatformPressable>) => {
   return (
     <PlatformPressable
+      accessibilityRole="tab"
       {...props}
       onPressIn={(ev) => {
         if (process.env.EXPO_OS === 'ios') {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -149,6 +149,7 @@ function Button({
           state.pressed && { opacity: 0.7 },
           typeof style === 'function' ? style(state) : style,
         ]}
+        accessibilityRole="button"
         role="button"
         {...props}
       >

--- a/src/components/ui/theme-switcher.tsx
+++ b/src/components/ui/theme-switcher.tsx
@@ -40,7 +40,12 @@ export const ThemeSwitcher = (props: { minimize?: boolean }) => {
   return (
     <>
       {props.minimize ? (
-        <Button variant="ghost" size="icon" onPress={sheet.onOpen}>
+        <Button
+          variant="ghost"
+          size="icon"
+          onPress={sheet.onOpen}
+          accessibilityLabel={t('common:themes.label')}
+        >
           {hasAdaptiveThemes ? (
             <DisplayIcon size={20} color={iconColor} />
           ) : (


### PR DESCRIPTION
Screen readers previously announced tab buttons by inferring nothing from the icon-only labels. Adds tabBarAccessibilityLabel per tab, sets accessibilityRole="tab" on HapticTab, mirrors the web-only role="button" with accessibilityRole="button" on Button (native), and labels the icon-only ThemeSwitcher button.